### PR TITLE
110: removed debt from group, will calculate debt from sqlite

### DIFF
--- a/lib/data/remote/dtos/group_dto.dart
+++ b/lib/data/remote/dtos/group_dto.dart
@@ -1,4 +1,3 @@
-import 'package:billsplit_flutter/data/remote/dtos/debts_dto.dart';
 import 'package:billsplit_flutter/data/remote/dtos/event_dto.dart';
 import 'package:billsplit_flutter/data/remote/dtos/person_dto.dart';
 import 'package:billsplit_flutter/extensions.dart';
@@ -14,7 +13,6 @@ class GroupDTO {
   final List<PersonDTO>? pastMembers;
   final PersonDTO createdBy;
   final num timestamp;
-  final List<DebtDTO> debts;
   final EventDTO? latestEvent;
   final String defaultCurrency;
 
@@ -26,7 +24,6 @@ class GroupDTO {
       required this.pastMembers,
       required this.createdBy,
       required this.timestamp,
-      required this.debts,
       required this.latestEvent});
 
   factory GroupDTO.fromJson(Json json) => _$GroupDTOFromJson(json);

--- a/lib/data/remote/dtos/group_dto.g.dart
+++ b/lib/data/remote/dtos/group_dto.g.dart
@@ -18,9 +18,6 @@ GroupDTO _$GroupDTOFromJson(Map<String, dynamic> json) => GroupDTO(
           .toList(),
       createdBy: PersonDTO.fromJson(json['createdBy'] as Map<String, dynamic>),
       timestamp: json['timestamp'] as num,
-      debts: (json['debts'] as List<dynamic>)
-          .map((e) => DebtDTO.fromJson(e as Map<String, dynamic>))
-          .toList(),
       latestEvent: json['latestEvent'] == null
           ? null
           : EventDTO.fromJson(json['latestEvent'] as Map<String, dynamic>),
@@ -33,7 +30,6 @@ Map<String, dynamic> _$GroupDTOToJson(GroupDTO instance) => <String, dynamic>{
       'pastMembers': instance.pastMembers?.map((e) => e.toJson()).toList(),
       'createdBy': instance.createdBy.toJson(),
       'timestamp': instance.timestamp,
-      'debts': instance.debts.map((e) => e.toJson()).toList(),
       'latestEvent': instance.latestEvent?.toJson(),
       'defaultCurrency': instance.defaultCurrency,
     };

--- a/lib/domain/mappers/groups_mapper.dart
+++ b/lib/domain/mappers/groups_mapper.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:billsplit_flutter/data/local/database/splitsby_db.dart';
 import 'package:billsplit_flutter/data/remote/dtos/group_dto.dart';
-import 'package:billsplit_flutter/domain/mappers/debts_mapper.dart';
 import 'package:billsplit_flutter/domain/mappers/event_mapper.dart';
 import 'package:billsplit_flutter/domain/mappers/person_mapper.dart';
 import 'package:billsplit_flutter/domain/models/group.dart';
@@ -24,8 +23,7 @@ extension GroupDtoExt on GroupDTO {
       createdBy: createdBy.toPerson(),
       pastMembers: pastMembers?.toPeople() ?? [],
       timestamp: timestamp,
-      latestEvent: latestEvent.toEvent(),
-      debts: debts.toDebts());
+      latestEvent: latestEvent.toEvent());
 
   GroupDb toDb() => GroupDb(groupId: id, group: json.encode(toJson()));
 }
@@ -39,7 +37,6 @@ extension GroupExt on Group {
       pastMembers: pastMembers.toDTO(),
       createdBy: createdBy.toDTO(),
       timestamp: timestamp,
-      debts: debtState.map((e) => e.toDTO()).toList(),
       latestEvent: latestEventState?.toEventDTO());
 
   GroupDb toDb() => toDTO().toDb();

--- a/lib/domain/models/group.dart
+++ b/lib/domain/models/group.dart
@@ -1,4 +1,3 @@
-import 'package:billsplit_flutter/domain/models/debt.dart';
 import 'package:billsplit_flutter/domain/models/event.dart';
 import 'package:billsplit_flutter/domain/models/person.dart';
 
@@ -10,13 +9,11 @@ class Group {
   final Person createdBy;
   final num timestamp;
   final Event? _latestEvent;
-  final List<Debt> _debts;
   final String _defaultCurrency;
 
   // modifiable values
   late String nameState = _name;
   late Event? latestEventState = _latestEvent;
-  late Iterable<Debt> debtState = _debts;
   late String defaultCurrencyState = _defaultCurrency;
 
   Group(
@@ -27,12 +24,10 @@ class Group {
       required this.createdBy,
       required this.timestamp,
       required Event? latestEvent,
-      required String defaultCurrency,
-      required Iterable<Debt> debts})
+      required String defaultCurrency})
       : _latestEvent = latestEvent,
         _name = name,
-        _defaultCurrency = defaultCurrency,
-        _debts = debts.toList();
+        _defaultCurrency = defaultCurrency;
 
   Iterable<Person> get allPeople => [...people, ...pastMembers];
 
@@ -46,7 +41,6 @@ class Group {
           timestamp: DateTime.now().millisecondsSinceEpoch,
           latestEvent: null,
           defaultCurrency: currency,
-          debts: [],
         );
 
   Group.mock(num seed)
@@ -58,12 +52,10 @@ class Group {
             createdBy: Person.dummy(2),
             timestamp: 0,
             defaultCurrency: "usd",
-            latestEvent: null,
-            debts: []);
+            latestEvent: null,);
 
   void reset() {
     nameState = _name;
-    debtState = _debts;
     latestEventState = _latestEvent;
   }
 }

--- a/lib/domain/use_cases/add_event_usecase.dart
+++ b/lib/domain/use_cases/add_event_usecase.dart
@@ -4,7 +4,6 @@ import 'package:billsplit_flutter/data/remote/api_service.dart';
 import 'package:billsplit_flutter/data/remote/dtos/debts_dto.dart';
 import 'package:billsplit_flutter/data/remote/dtos/event_dto.dart';
 import 'package:billsplit_flutter/di/get_it.dart';
-import 'package:billsplit_flutter/domain/mappers/debts_mapper.dart';
 import 'package:billsplit_flutter/domain/mappers/event_mapper.dart';
 import 'package:billsplit_flutter/domain/mappers/group_expense_mapper.dart';
 import 'package:billsplit_flutter/domain/mappers/groups_mapper.dart';
@@ -27,7 +26,6 @@ class AddEventUseCase {
     if (event is GroupExpense) {
       final expenseDb = event.toDb(groupId, SyncState.pending, tempId: tempId);
       await _database.groupExpenseDAO.insert(expenseDb);
-      await Future.delayed(const Duration(seconds: 2));
     }
 
     try {
@@ -50,14 +48,6 @@ class AddEventUseCase {
         await _database.paymentsDAO.insert(paymentDb);
       }
 
-      // update group
-      final groupResponse = await _database.groupsDAO.getGroup(groupId);
-      final group = groupResponse.toGroup();
-      group.debtState = debt.toDebts();
-      if (eventDto.toEvent() != null) {
-        group.latestEventState = eventDto.toEvent();
-      }
-      await _database.groupsDAO.insertGroup(group.toDb());
     } catch (e) {
       if (event is GroupExpense) {
         final expenseDb = event.toDb(groupId, SyncState.failed, tempId: tempId);

--- a/lib/domain/use_cases/delete_expense_usecase.dart
+++ b/lib/domain/use_cases/delete_expense_usecase.dart
@@ -3,7 +3,6 @@ import 'package:billsplit_flutter/data/local/database/splitsby_db.dart';
 import 'package:billsplit_flutter/data/remote/api_service.dart';
 import 'package:billsplit_flutter/data/remote/dtos/debts_dto.dart';
 import 'package:billsplit_flutter/di/get_it.dart';
-import 'package:billsplit_flutter/domain/mappers/debts_mapper.dart';
 import 'package:billsplit_flutter/domain/mappers/group_expense_mapper.dart';
 import 'package:billsplit_flutter/domain/mappers/groups_mapper.dart';
 import 'package:billsplit_flutter/domain/mappers/payment_mapper.dart';
@@ -28,7 +27,6 @@ class DeleteExpenseUseCase {
     await _database.groupExpenseDAO.deleteExpense(expense.id);
 
     // update group
-    group.debtState = debtDTO.toDebts();
     await _database.groupsDAO.insertGroup(group.toDb());
   }
 

--- a/lib/presentation/features/group/group_page.dart
+++ b/lib/presentation/features/group/group_page.dart
@@ -37,8 +37,9 @@ class GroupPage extends StatelessWidget {
               builder: (context) {
                 if (state is GroupState) {
                   if (state.nav == GroupPageNav.debt) return const SizedBox();
-                  if (state.nav == GroupPageNav.settings)
+                  if (state.nav == GroupPageNav.settings) {
                     return const SizedBox();
+                  }
                   String text = state.nav == GroupPageNav.events
                       ? "Add expense"
                       : "Add subscription";

--- a/lib/presentation/features/groups/bloc/groups_bloc.dart
+++ b/lib/presentation/features/groups/bloc/groups_bloc.dart
@@ -1,7 +1,9 @@
+import 'package:billsplit_flutter/domain/models/currency.dart';
 import 'package:billsplit_flutter/domain/models/group.dart';
 import 'package:billsplit_flutter/domain/use_cases/currency_usecases/convert_currency_use_case.dart';
 import 'package:billsplit_flutter/domain/use_cases/get_friends_usecase.dart';
 import 'package:billsplit_flutter/domain/use_cases/get_groups_usecase.dart';
+import 'package:billsplit_flutter/domain/use_cases/observe_debts_usecase.dart';
 import 'package:billsplit_flutter/domain/use_cases/observe_groups_usecase.dart';
 import 'package:billsplit_flutter/presentation/base/bloc/base_cubit.dart';
 import 'package:billsplit_flutter/presentation/base/bloc/base_state.dart';
@@ -12,6 +14,8 @@ class GroupsBloc extends BaseCubit {
   final _getFriendsUseCase = GetFriendsUseCase();
   final _observeGroupsUseCase = ObserveGroupsUseCase();
   final _convertCurrencyUseCase = ConvertCurrencyUseCase();
+  final _observeDebtsUseCase = ObserveDebtsUseCase();
+
 
   GroupsBloc() : super();
 
@@ -31,6 +35,14 @@ class GroupsBloc extends BaseCubit {
     });
   }
 
+  Stream<num> getDebtsStream(String groupId) =>
+      _observeDebtsUseCase.observe(groupId).map((event) {
+        if (event.length > 1) {
+          return event.map((e) => e.second).sum;
+        }
+        return event.first.second;
+      });
+
   Future refreshGroups() async {
     try {
       await _getGroupsUseCase.launch();
@@ -40,6 +52,6 @@ class GroupsBloc extends BaseCubit {
   }
 
   num convertToDefault(Group group, num debt) {
-    return _convertCurrencyUseCase.launch(debt, "usd", group.defaultCurrencyState);
+    return _convertCurrencyUseCase.launch(debt, Currency.USD().symbol, group.defaultCurrencyState);
   }
 }

--- a/lib/presentation/features/groups/widgets/group_view.dart
+++ b/lib/presentation/features/groups/widgets/group_view.dart
@@ -6,7 +6,6 @@ import 'package:billsplit_flutter/presentation/features/group/group_page.dart';
 import 'package:billsplit_flutter/presentation/features/groups/bloc/groups_bloc.dart';
 import 'package:billsplit_flutter/presentation/themes/splitsby_text_theme.dart';
 import 'package:billsplit_flutter/utils/utils.dart';
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -18,11 +17,6 @@ class GroupView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final cubit = context.read<GroupsBloc>();
-    final yourDebts = group.debtState
-            .where((element) => element.userId == cubit.user.uid)
-            .firstOrNull
-            ?.owes ??
-        0;
 
     return Center(
       child: ClickableListItem(
@@ -58,7 +52,16 @@ class GroupView extends StatelessWidget {
                       size: 30,
                       limit: 3,
                     ),
-                    Expanded(child: _debtView(context, group, yourDebts)),
+                    StreamBuilder(
+                        stream: cubit.getDebtsStream(group.id),
+                        builder: (context, snapshot) {
+                          if (snapshot.hasData) {
+                            return Expanded(
+                                child: _debtView(
+                                    context, group, snapshot.requireData));
+                          }
+                          return const SizedBox();
+                        })
                   ],
                 ),
               ],

--- a/test/debt_calculator_test.dart
+++ b/test/debt_calculator_test.dart
@@ -23,7 +23,6 @@ final sampleGroup = Group(
     people: samplePeopleShera,
     createdBy: samplePeopleShera.first,
     timestamp: 0,
-    debts: [],
     latestEvent: null);
 
 final sampleIndividualExpenses = samplePeopleShera.toList().mapIndexed(


### PR DESCRIPTION
Maintaining debt on the group doc was tedious and error prone. This new approach will switch to calculating the debt based on the expenses in the SQLite DB. The drawback is that the user will need to visit a group to properly synchronize it